### PR TITLE
Adds methods to emit messages w/ optional file annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ if __name__ == "__main__":
 Do not forget to run `. ./activate.sh`.
 
 # Scripts
-Install [invoke](https://docs.pyinvoke.org/en/stable/) preferably with [pipx](https://pypa.github.io/pipx/):
 
-    pipx install invoke
+Install [invoke](https://docs.pyinvoke.org/en/stable/) and [pre-commit](https://pre-commit.com/)
+preferably with [pipx](https://pypa.github.io/pipx/):
+
+    pipx install invoke pre-commit
 
 For a list of available scripts run:
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
   - outputs.md
   - github_env_vars.md
   - main.md
+  - messages.md
   - summary.md
   - render.md
 

--- a/docs/src/en/messages.md
+++ b/docs/src/en/messages.md
@@ -1,0 +1,11 @@
+::: github_custom_actions.ActionBase.debug
+    options:
+      show_root_heading: true
+      heading_level: 2
+      show_submodules: false
+
+::: github_custom_actions.ActionBase.message
+    options:
+      show_root_heading: true
+      heading_level: 2
+      show_submodules: false

--- a/src/github_custom_actions/action_base.py
+++ b/src/github_custom_actions/action_base.py
@@ -141,8 +141,8 @@ class ActionBase:
         """
         print(f"::debug::{message}")
 
+    @staticmethod
     def message(  # noqa: PLR0913
-        self,
         severity: Literal["error", "notice", "warning"],
         message: str,
         title: Optional[str] = None,

--- a/src/github_custom_actions/action_base.py
+++ b/src/github_custom_actions/action_base.py
@@ -132,6 +132,12 @@ class ActionBase:
         """
         Emits a debug message. The runner needs to be invoked with enabled debug
         logging to show these.
+
+        Example usage:
+
+        ```python
+        self.debug("Action invoked.")
+        ```
         """
         print(f"::debug::{message}")
 
@@ -155,6 +161,23 @@ class ActionBase:
 
         There are also the methods `error_message`, `notice_message` and
         `warning_message` as shortcuts.
+
+        Example usages:
+
+        ```python
+        self.message("warning", "Deprecated input used: pattern")
+        # or equivalently:
+        self.warning_message("Deprecated input used: pattern")
+
+        self.error_message(
+            "Value exceeds limit.",
+            title="Schema error",
+            file="config.yml",
+            line=7,
+            column=42
+        )
+        ```
+
         """
         _locals = locals().copy()
         parameters = ",".join(

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,0 +1,18 @@
+def test_debug_message(action, capsys):
+    action.debug("foo waz here")
+    assert capsys.readouterr().out == "::debug::foo waz here\n"
+
+
+def test_error_message(action, capsys):
+    action.error_message("An error.", title="Error", file="test.txt", line=4)
+    assert capsys.readouterr().out == "::error title=Error,file=test.txt,line=4::An error.\n"
+
+
+def test_notice_message(action, capsys):
+    action.notice_message("A notice.")
+    assert capsys.readouterr().out == "::notice::A notice.\n"
+
+
+def test_warning_message(action, capsys):
+    action.warning_message("Warning!", file="test.txt")
+    assert capsys.readouterr().out == "::warning file=test.txt::Warning!\n"


### PR DESCRIPTION
This adds convenience methods to emit messages that can optionally point to file contents.

This feature is enough to reach what i previously wanted to achieve with problem markers, so indeed #4 wouldn't be useful.